### PR TITLE
Fixed a crash. ZENIDEEditorContextDependencyManager didn't respond to…

### DIFF
--- a/Zen/Zen/ZENIDEEditorContextDependencyManager.m
+++ b/Zen/Zen/ZENIDEEditorContextDependencyManager.m
@@ -42,7 +42,6 @@
     }
 }
 
-
 // Checking whether a component is "valid" is omnipresent in IDEKit
 - (BOOL)isValid
 {
@@ -55,6 +54,11 @@
 }
 
 - (id)editorModeViewController
+{
+    return nil;
+}
+
+- (id)debugSessionController
 {
     return nil;
 }


### PR DESCRIPTION
… debugSessionController method

This method returns nil in this implementation for simplicity reasons
