### PR TITLE
Added support for Xcode 7.2.1 (7C1002).

### DIFF
--- a/Zen/Info.plist
+++ b/Zen/Info.plist
@@ -34,6 +34,7 @@
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
+		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>


### PR DESCRIPTION
This only makes the plug-in compatible with Xcode 7.2.1. It does _not_ fix any other issues with the 7.2 line — in my case the plugin is now loaded, but crashes when I switch to distraction free mode.
