### PR TITLE
Fix "No Editor" in macOS Sierra by giving the editorContext a tab controller

### DIFF
--- a/Zen/Zen.m
+++ b/Zen/Zen.m
@@ -136,6 +136,10 @@ static Zen *sharedPlugin;
     } else {
         NSWindowController *windowController = [self makeWindowController];
         
+        if (!windowController) {
+            return;
+        }
+        
         [windowController showWindow:self];
         [windowController.window setFrame:[[NSScreen mainScreen] frame] display:YES];
         [windowController.window toggleFullScreen:self];
@@ -180,7 +184,10 @@ static Zen *sharedPlugin;
     windowController.window.collectionBehavior = window.collectionBehavior | NSWindowCollectionBehaviorFullScreenPrimary;
     
     // ORDER IMPORTANT HERE! This method should be called when an IDEEditorContext is in a window. All dependencies are resolved then #XcodeArchitecture
-    [editorContext openEditorOpenSpecifier:editorConfiguration.openSpecifier];
+    editorContext.workspaceTabController = editorConfiguration.tabController;
+    if (![editorContext openEditorOpenSpecifier:editorConfiguration.openSpecifier]) {
+        NSLog(@"WCDistractionFreePlugin: Unable to open editor:\n%@", editorConfiguration.openSpecifier);
+    }
     
     return windowController;
 }


### PR DESCRIPTION
Hey, running macOS Sierra Seed 1 (16A201w) and Xcode 7.3.1 GM (7D1014) and getting:

![screenshot 2016-06-28 17 51 01](https://cloud.githubusercontent.com/assets/133818/16422588/3b8e3316-3d59-11e6-9e6d-a4772e9f4d3b.png)

When calling `-[editorContext openEditorOpenSpecifier:editorConfiguration.openSpecifier]` in `-[ZEN makeWindowController]`, 
`-[IDEEditorContext _navigableItemForEditingFromArchivedRepresentation:error:]` was bailing because it couldn't find a workspace tab controller. macOS Sierra pushed Safari's tab controller systemwide, so maybe that has something to do with it...

This PR gives the editor context the active tab controller.

_Seems_ to work now. Not tested on anything other than macOS Sierra Seed 1 and Xcode 7.3.1 GM.
